### PR TITLE
[WS-240] Much better global warps

### DIFF
--- a/src/Language.yml
+++ b/src/Language.yml
@@ -111,6 +111,7 @@ ENG:
   Previous_Page: Previous Page
   Next_Page: Next Page
   GlobalWarp_Created: '&7The GlobalWarp "&b%GLOBAL_WARP%&7" was &acreated successfully&7.'
+  GlobalWarp_Create_No_Dots: '&cGlobalWarp names &lcan''t &ccontain any points!'
   Target_Server: Target-Server
   GUI_Choose_Icon: Choose your IconType
   Warp: Warp
@@ -377,6 +378,7 @@ GER:
   Previous_Page: Vorherige Seite
   Next_Page: 'Nächste Seite'
   GlobalWarp_Created: '&7Der GlobalWarp "&b%GLOBAL_WARP%&7" wurde &aerfolgreich erstellt&7.'
+  GlobalWarp_Create_No_Dots: '&cGlobalWarp-Namen dürfen &lkeine&c Punkte enthalten!'
   Target_Server: Ziel-Server
   GUI_Choose_Icon: 'Wähle deinen Symbol-Typen'
   Warp: Warp

--- a/src/de/codingair/warpsystem/spigot/api/SpigotAPI.java
+++ b/src/de/codingair/warpsystem/spigot/api/SpigotAPI.java
@@ -1,9 +1,13 @@
 package de.codingair.warpsystem.spigot.api;
 
+import de.codingair.codingapi.server.reflections.IReflection;
+import de.codingair.codingapi.server.reflections.PacketUtils;
 import de.codingair.warpsystem.spigot.api.blocks.listeners.RuleListener;
-import de.codingair.warpsystem.spigot.api.packetreader.GlobalPacketReaderManager;
 import de.codingair.warpsystem.spigot.api.packetreader.GlobalPacketReaderListener;
+import de.codingair.warpsystem.spigot.api.packetreader.GlobalPacketReaderManager;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class SpigotAPI {
@@ -29,5 +33,36 @@ public class SpigotAPI {
 
     public GlobalPacketReaderManager getGlobalPacketReaderManager() {
         return globalPacketReaderManager;
+    }
+
+    public boolean silentTeleport(Player player, Location to) {
+        Location from = player.getLocation();
+
+        Object entity = PacketUtils.getEntityPlayer(player);
+
+        if(player.getHealth() != 0.0D && !player.isDead()) {
+            IReflection.MethodAccessor isDisconnected = IReflection.getMethod(PacketUtils.PlayerConnectionClass, "isDisconnected", boolean.class, new Class[] {});
+            IReflection.MethodAccessor mount = IReflection.getMethod(PacketUtils.EntityPlayerClass, "mount", new Class[] {PacketUtils.EntityClass});
+            IReflection.MethodAccessor teleport = IReflection.getMethod(PacketUtils.PlayerConnectionClass, "teleport", new Class[] {Location.class});
+            IReflection.FieldAccessor activeContainer = IReflection.getField(PacketUtils.EntityPlayerClass, "activeContainer");
+            IReflection.FieldAccessor defaultContainer = IReflection.getField(PacketUtils.EntityPlayerClass, "defaultContainer");
+            IReflection.FieldAccessor dimension = IReflection.getField(PacketUtils.WorldServerClass, "dimension");
+
+            if(PacketUtils.playerConnection.get(entity) != null && !((boolean) isDisconnected.invoke(PacketUtils.playerConnection.get(entity)))) {
+
+                mount.invoke(entity, (Object) null);
+                Object fromWorld = PacketUtils.getWorldServer(from.getWorld());
+                Object toWorld = PacketUtils.getWorldServer(to.getWorld());
+
+                if(activeContainer.get(entity) != defaultContainer.get(entity)) {
+                    player.closeInventory();
+                }
+
+                if(fromWorld == toWorld) teleport.invoke(PacketUtils.playerConnection.get(entity), to);
+                else PacketUtils.moveToWorld.invoke(PacketUtils.getHandleCraftServer.invoke(PacketUtils.CraftServerClass.cast(player.getServer())), entity, dimension.get(toWorld), true, to, true);
+
+                return true;
+            } else return false;
+        } else return false;
     }
 }

--- a/src/de/codingair/warpsystem/spigot/api/blocks/StaticLavaBlock.java
+++ b/src/de/codingair/warpsystem/spigot/api/blocks/StaticLavaBlock.java
@@ -6,11 +6,13 @@ import de.codingair.warpsystem.spigot.api.blocks.utils.StaticBlock;
 import org.bukkit.Location;
 
 public class StaticLavaBlock extends StaticBlock {
-    private boolean spreadFire = true;
-    private boolean hitEntity = true;
+    private boolean spreadFire;
+    private boolean hitEntity;
 
     public StaticLavaBlock(Location location) {
         super(location);
+        spreadFire = false;
+        hitEntity = false;
     }
 
     @Override

--- a/src/de/codingair/warpsystem/spigot/api/blocks/listeners/RuleListener.java
+++ b/src/de/codingair/warpsystem/spigot/api/blocks/listeners/RuleListener.java
@@ -36,6 +36,7 @@ public class RuleListener implements Listener {
 
     @EventHandler
     public void onBurn(BlockIgniteEvent e) {
+        if(e.getIgnitingBlock() == null) return;
         List<StaticLavaBlock> l = API.getRemovables(StaticLavaBlock.class);
 
         for(StaticLavaBlock lava : l) {

--- a/src/de/codingair/warpsystem/spigot/base/managers/TeleportManager.java
+++ b/src/de/codingair/warpsystem/spigot/base/managers/TeleportManager.java
@@ -204,10 +204,14 @@ public class TeleportManager {
     }
 
     public void teleport(Player player, Location location, String displayName, double costs, boolean skip, boolean canMove, String message) {
-        teleport(player, location, displayName, costs, skip, canMove, message, null);
+        teleport(player, location, displayName, costs, skip, canMove, message, false, null);
     }
 
-    public void teleport(Player player, Location location, String displayName, double costs, boolean skip, boolean canMove, String message, Callback<Boolean> callback) {
+    public void teleport(Player player, Location location, String displayName, double costs, boolean skip, boolean canMove, String message, boolean silent) {
+        teleport(player, location, displayName, costs, skip, canMove, message, silent, null);
+    }
+
+    public void teleport(Player player, Location location, String displayName, double costs, boolean skip, boolean canMove, String message, boolean silent, Callback<Boolean> callback) {
         if(isTeleporting(player)) {
             Teleport teleport = getTeleport(player);
             long diff = System.currentTimeMillis() - teleport.getStartTime();
@@ -218,7 +222,7 @@ public class TeleportManager {
 
         player.closeInventory();
 
-        Teleport teleport = new Teleport(player, location, displayName, costs, message, canMove, callback);
+        Teleport teleport = new Teleport(player, location, displayName, costs, message, canMove, silent, callback);
         this.teleports.add(teleport);
 
         if(seconds == 0 || (WarpSystem.OP_CAN_SKIP_DELAY && player.hasPermission(WarpSystem.PERMISSION_ByPass_Teleport_Delay)) || skip) teleport.teleport();

--- a/src/de/codingair/warpsystem/spigot/base/utils/effects/RotatingParticleSpiral.java
+++ b/src/de/codingair/warpsystem/spigot/base/utils/effects/RotatingParticleSpiral.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
 public class RotatingParticleSpiral extends BukkitRunnable {
-    private static final double CHANGE = 0.1;
+    private static final double CHANGE = 0.2;
     private static final double HEIGHT = 2.4;
 
     private Player player;

--- a/src/de/codingair/warpsystem/spigot/features/globalwarps/commands/CGlobalWarps.java
+++ b/src/de/codingair/warpsystem/spigot/features/globalwarps/commands/CGlobalWarps.java
@@ -57,13 +57,19 @@ public class CGlobalWarps extends CommandBuilder {
             @Override
             public boolean runCommand(CommandSender sender, String label, String argument, String[] args) {
                 Player player = (Player) sender;
+
+                if(argument.contains(".")) {
+                    player.sendMessage(Lang.getPrefix() + Lang.get("GlobalWarp_Create_No_Dots"));
+                    return false;
+                }
+
                 ((GlobalWarpManager) WarpSystem.getInstance().getDataManager().getManager(FeatureType.GLOBAL_WARPS)).create(argument, player.getLocation(), new Callback<Boolean>() {
                     @Override
                     public void accept(Boolean created) {
                         if(created) {
-                            sender.sendMessage(Lang.getPrefix() + Lang.get("GlobalWarp_Created").replace("%GLOBAL_WARP%", argument));
+                            player.sendMessage(Lang.getPrefix() + Lang.get("GlobalWarp_Created").replace("%GLOBAL_WARP%", argument));
                         } else {
-                            sender.sendMessage(Lang.getPrefix() + Lang.get("GlobalWarp_Create_Name_Already_Exists").replace("%GLOBAL_WARP%", argument));
+                            player.sendMessage(Lang.getPrefix() + Lang.get("GlobalWarp_Create_Name_Already_Exists").replace("%GLOBAL_WARP%", argument));
                         }
                     }
                 });

--- a/src/de/codingair/warpsystem/spigot/features/globalwarps/listeners/GlobalWarpListener.java
+++ b/src/de/codingair/warpsystem/spigot/features/globalwarps/listeners/GlobalWarpListener.java
@@ -1,6 +1,7 @@
 package de.codingair.warpsystem.spigot.features.globalwarps.listeners;
 
-import de.codingair.codingapi.server.Sound;
+import de.codingair.codingapi.tools.time.TimeList;
+import de.codingair.codingapi.tools.time.TimeMap;
 import de.codingair.warpsystem.spigot.base.WarpSystem;
 import de.codingair.warpsystem.spigot.base.language.Lang;
 import de.codingair.warpsystem.spigot.features.FeatureType;
@@ -19,18 +20,77 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class GlobalWarpListener implements PacketListener {
+public class GlobalWarpListener implements Listener, PacketListener {
+    private TimeMap<String, TeleportPacket> teleport = new TimeMap<>();
+    private TimeList<Player> noTeleport = new TimeList<>();
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onJoin(PlayerJoinEvent e) {
+        join(e.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onLogin(PlayerLoginEvent e) {
+        join(e.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onTeleport(PlayerTeleportEvent e) {
+        if(noTeleport.contains(e.getPlayer())) e.setCancelled(true);
+    }
+
+    private void join(Player player) {
+        TeleportPacket packet = teleport.remove(player.getName());
+
+        if(packet != null) {
+            noTeleport.add(player, 1);
+
+            SGlobalWarp warp = packet.getWarp();
+            Location location = new Location(Bukkit.getWorld(warp.getLoc().getWorld()), warp.getLoc().getX(), warp.getLoc().getY(), warp.getLoc().getZ(), warp.getLoc().getYaw(), warp.getLoc().getPitch());
+            String warpDisplayName = packet.getTeleportDisplayName();
+
+            if(player != null) {
+                if(location.getWorld() == null) {
+                    player.sendMessage(Lang.getPrefix() + "§4World '" + warp.getLoc().getWorld() + "' is missing. Please contact an admin!");
+                    return;
+                }
+
+                String message = null;
+                if(WarpSystem.getInstance().getFileManager().getFile("Config").getConfig().getBoolean("WarpSystem.Send.Teleport_Message", true) || packet.getCosts() > 0) {
+                    if(packet.getCosts() > 0) {
+                        message = Lang.getPrefix() + Lang.get("Money_Paid").replace("%AMOUNT%", packet.getCosts() + "").replace("%warp%", ChatColor.translateAlternateColorCodes('&', warpDisplayName));
+                    } else {
+                        message = Lang.getPrefix() + Lang.get("Teleported_To").replace("%warp%", ChatColor.translateAlternateColorCodes('&', warpDisplayName));
+                    }
+                }
+
+                String finalMessage = message;
+                Bukkit.getScheduler().runTaskLater(WarpSystem.getInstance(), () -> WarpSystem.getInstance().getTeleportManager().teleport(player, location, warpDisplayName, 0, true, true, finalMessage, true, null), 2L);
+            }
+        }
+    }
+
     @Override
     public void onReceive(Packet packet, String extra) {
         IconManager manager = WarpSystem.getInstance().getDataManager().getManager(FeatureType.WARPS);
 
         switch(PacketType.getByObject(packet)) {
             case SendGlobalWarpNamesPacket:
-                ((GlobalWarpManager) WarpSystem.getInstance().getDataManager().getManager(FeatureType.GLOBAL_WARPS)).getGlobalWarps().putAll(((SendGlobalWarpNamesPacket) packet).getNames());
+                GlobalWarpManager gwManager = WarpSystem.getInstance().getDataManager().getManager(FeatureType.GLOBAL_WARPS);
+                if(((SendGlobalWarpNamesPacket) packet).isStart()) {
+                    gwManager.getGlobalWarps().clear();
+                }
+                gwManager.getGlobalWarps().putAll(((SendGlobalWarpNamesPacket) packet).getNames());
                 break;
 
             case UpdateGlobalWarpPacket:
@@ -59,27 +119,11 @@ public class GlobalWarpListener implements PacketListener {
 
             case TeleportPacket:
                 Player player = Bukkit.getPlayer(((TeleportPacket) packet).getPlayer());
-                SGlobalWarp warp = ((TeleportPacket) packet).getWarp();
-                Location location = new Location(Bukkit.getWorld(warp.getLoc().getWorld()), warp.getLoc().getX(), warp.getLoc().getY(), warp.getLoc().getZ(), warp.getLoc().getYaw(), warp.getLoc().getPitch());
-                String warpDisplayName = ((TeleportPacket) packet).getTeleportDisplayName();
 
                 if(player != null) {
-                    if(location.getWorld() == null) {
-                        player.sendMessage(Lang.getPrefix() + "§4World '" + warp.getLoc().getWorld() + "' is missing. Please contact an admin!");
-                        return;
-                    }
-
-                    String message = null;
-                    if(WarpSystem.getInstance().getFileManager().getFile("Config").getConfig().getBoolean("WarpSystem.Send.Teleport_Message", true) || ((TeleportPacket) packet).getCosts() > 0) {
-                        if(((TeleportPacket) packet).getCosts() > 0) {
-                            message = Lang.getPrefix() + Lang.get("Money_Paid").replace("%AMOUNT%", ((TeleportPacket) packet).getCosts() + "").replace("%warp%", ChatColor.translateAlternateColorCodes('&', warpDisplayName));
-                        } else {
-                            message = Lang.getPrefix() + Lang.get("Teleported_To").replace("%warp%", ChatColor.translateAlternateColorCodes('&', warpDisplayName));
-                        }
-                    }
-
-                    WarpSystem.getInstance().getTeleportManager().teleport(player, location, warpDisplayName, 0, true, true, message);
-                }
+                    teleport.put(((TeleportPacket) packet).getPlayer(), (TeleportPacket) packet);
+                    join(player);
+                } else teleport.put(((TeleportPacket) packet).getPlayer(), (TeleportPacket) packet, 10);
                 break;
         }
     }

--- a/src/de/codingair/warpsystem/spigot/features/nativeportals/managers/NativePortalManager.java
+++ b/src/de/codingair/warpsystem/spigot/features/nativeportals/managers/NativePortalManager.java
@@ -124,8 +124,7 @@ public class NativePortalManager implements Manager {
             if(NativePortalManager.getInstance().isEditing(player) || API.getRemovable(player, GEditor.class) != null) {
                 player.setVelocity(player.getLocation().getDirection().normalize().multiply(-0.8));
                 return;
-            }
-            else if(API.getRemovable(player, GUI.class) != null) return;
+            } else if(API.getRemovable(player, GUI.class) != null) return;
             else if(WarpSystem.getInstance().getTeleportManager().isTeleporting(player)) return;
 
             if(goingToDelete.contains(player.getName())) {

--- a/src/de/codingair/warpsystem/spigot/features/tempwarps/managers/TeleportManager.java
+++ b/src/de/codingair/warpsystem/spigot/features/tempwarps/managers/TeleportManager.java
@@ -50,7 +50,7 @@ public class TeleportManager {
             AdapterType.getActive().setMoney(player, AdapterType.getActive().getMoney(player) - costs);
         }
 
-        WarpSystem.getInstance().getTeleportManager().teleport(player, warp.getLocation(), warp.getName(), warp.getTeleportCosts(), false, false, warp.getMessage(), isOwner ? null : new Callback<Boolean>() {
+        WarpSystem.getInstance().getTeleportManager().teleport(player, warp.getLocation(), warp.getName(), warp.getTeleportCosts(), false, false, warp.getMessage(), false, isOwner ? null : new Callback<Boolean>() {
             @Override
             public void accept(Boolean teleported) {
                 if(teleported) {

--- a/src/de/codingair/warpsystem/transfer/packets/bungee/SendGlobalWarpNamesPacket.java
+++ b/src/de/codingair/warpsystem/transfer/packets/bungee/SendGlobalWarpNamesPacket.java
@@ -12,12 +12,19 @@ import java.util.List;
 
 public class SendGlobalWarpNamesPacket implements Packet {
     private HashMap<String, String> names = new HashMap<>();
+    private boolean start;
 
     public SendGlobalWarpNamesPacket() {
     }
 
     public SendGlobalWarpNamesPacket(HashMap<String, String> names) {
         this.names = names;
+        this.start = false;
+    }
+
+    public SendGlobalWarpNamesPacket(HashMap<String, String> names, boolean start) {
+        this.names = names;
+        this.start = start;
     }
 
     @Override
@@ -29,6 +36,7 @@ public class SendGlobalWarpNamesPacket implements Packet {
         for(String server : this.names.values()) {
             out.writeUTF(server);
         }
+        out.writeBoolean(this.start);
     }
 
     @Override
@@ -40,9 +48,14 @@ public class SendGlobalWarpNamesPacket implements Packet {
         for(String name : this.names.keySet()) {
             this.names.replace(name, in.readUTF());
         }
+        this.start = in.readBoolean();
     }
 
     public HashMap<String, String> getNames() {
         return names;
+    }
+
+    public boolean isStart() {
+        return start;
     }
 }


### PR DESCRIPTION
* Prevent from global warp name containing dots (".")
* A silent teleport, which can't be cancelled
* GlobalWarps now always up to date (will be update if a player is online or joins to a server, where the new player is the first one)
* Prevent from deadlock if a global warp does not exist (sending an answer)
* Better synchronization for multiple packet commits (set a start packet)

NativePortals
* Prevent lava blocks from igniting blocks around