### PR TITLE
[WS-129] Fixed effect portals links (NPE on saving sounds)

### DIFF
--- a/src/de/codingair/warpsystem/spigot/api/blocks/utils/Block.java
+++ b/src/de/codingair/warpsystem/spigot/api/blocks/utils/Block.java
@@ -25,7 +25,8 @@ public abstract class Block implements Removable {
     @Override
     public void destroy() {
         API.removeRemovable(this);
-        Bukkit.getScheduler().runTask(WarpSystem.getInstance(), () -> location.getBlock().setType(Material.AIR));
+        if(WarpSystem.getInstance().isEnabled())
+            Bukkit.getScheduler().runTask(WarpSystem.getInstance(), () -> location.getBlock().setType(Material.AIR));
     }
 
     @Override

--- a/src/de/codingair/warpsystem/spigot/features/effectportals/utils/EffectPortal.java
+++ b/src/de/codingair/warpsystem/spigot/features/effectportals/utils/EffectPortal.java
@@ -207,9 +207,9 @@ public class EffectPortal extends FeatureObject implements Removable {
         json.put("ep.holo.pos", this.holoPos.toJSON(4));
         json.put("ep.link", this.link == null ? null : this.link.getLocation().toJSON(4));
         json.put("ep.link.use", useLink);
-        json.put("ep.sound.type", teleportSound.getSound().name());
-        json.put("ep.sound.volume", teleportSound.getVolume());
-        json.put("ep.sound.pitch", teleportSound.getPitch());
+        json.put("ep.sound.type", teleportSound == null ? null : teleportSound.getSound().name());
+        json.put("ep.sound.volume", teleportSound == null ? null : teleportSound.getVolume());
+        json.put("ep.sound.pitch", teleportSound == null ? null : teleportSound.getPitch());
     }
 
     @Override


### PR DESCRIPTION
* NativePortals don't have to set the portal blocks to air in the onDisable part (forced a IllegalAccessException)