### PR TITLE
[WS-182] Fixes NPE for TempWarps

### DIFF
--- a/src/de/codingair/warpsystem/bungee/base/language/Lang.java
+++ b/src/de/codingair/warpsystem/bungee/base/language/Lang.java
@@ -15,6 +15,8 @@ public class Lang {
         List<String> languages = new ArrayList<>();
         languages.add("ENG.yml");
         languages.add("GER.yml");
+        languages.add("ES.yml");
+        languages.add("FRA.yml");
 
         File folder = new File(plugin.getDataFolder(), "/Languages/");
         if(!folder.exists()) mkDir(folder);

--- a/src/de/codingair/warpsystem/spigot/features/tempwarps/managers/TempWarpManager.java
+++ b/src/de/codingair/warpsystem/spigot/features/tempwarps/managers/TempWarpManager.java
@@ -564,10 +564,13 @@ public class TempWarpManager implements Manager, Ticker {
     }
 
     public TempWarp getWarp(String identifier) {
+        if(identifier == null) return null;
+
         identifier = ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', identifier.replace("_", " ")));
         List<TempWarp> warps = new ArrayList<>(this.warps);
 
         for(TempWarp warp : warps) {
+            if(warp.getIdentifier() == null) continue;
             if(warp.getIdentifier().replace("_", " ").equalsIgnoreCase(identifier)) {
                 warps.clear();
                 return warp;


### PR DESCRIPTION
* Fixes not auto creating language files on BungeeCord

This issue occurs while creating the name of a TempWarp. But this only a few times. If somebody toggles his own TempWarp from private to public and the name of this TempWarp is already taken then it will be set to null. If you create a new TempWarp in this moment (between toggling it to public and setting a new name) my plugin tries to search for TempWarps (to prevent doubled names) and got that name from above (null) and directly throws a NullPointerException.