### PR TITLE
[WS-256] PlayerWarp icons will be displayed correctly now

### DIFF
--- a/src/de/codingair/warpsystem/spigot/features/nativeportals/NativePortal.java
+++ b/src/de/codingair/warpsystem/spigot/features/nativeportals/NativePortal.java
@@ -2,8 +2,10 @@ package de.codingair.warpsystem.spigot.features.nativeportals;
 
 import de.codingair.codingapi.server.blocks.utils.Axis;
 import de.codingair.codingapi.tools.Area;
-import de.codingair.codingapi.tools.io.utils.DataWriter;
+import de.codingair.codingapi.tools.Location;
 import de.codingair.codingapi.tools.io.JSON.JSON;
+import de.codingair.codingapi.tools.io.lib.JSONArray;
+import de.codingair.codingapi.tools.io.utils.DataWriter;
 import de.codingair.warpsystem.spigot.base.utils.featureobjects.FeatureObject;
 import de.codingair.warpsystem.spigot.base.utils.featureobjects.actions.Action;
 import de.codingair.warpsystem.spigot.base.utils.featureobjects.actions.types.WarpAction;
@@ -15,12 +17,10 @@ import de.codingair.warpsystem.spigot.features.nativeportals.utils.PortalListene
 import de.codingair.warpsystem.spigot.features.nativeportals.utils.PortalType;
 import de.codingair.warpsystem.spigot.features.simplewarps.SimpleWarp;
 import de.codingair.warpsystem.spigot.features.simplewarps.managers.SimpleWarpManager;
-import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
-import de.codingair.codingapi.tools.io.lib.JSONArray;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,7 +31,7 @@ public class NativePortal extends FeatureObject {
     private PortalType type;
     private boolean editMode = false;
 
-    private List<PortalBlock> blocks = new ArrayList<>();
+    private List<PortalBlock> blocks;
     private boolean visible = false;
     private List<PortalListener> listeners = new ArrayList<>();
 
@@ -122,7 +122,7 @@ public class NativePortal extends FeatureObject {
             for(Object o : jsonArray) {
                 if(o instanceof Map) {
                     JSON json = new JSON((Map<?, ?>) o);
-                    de.codingair.codingapi.tools.Location loc = new de.codingair.codingapi.tools.Location();
+                    Location loc = new Location();
                     loc.read(json);
 
                     if(loc.getWorld() == null) {
@@ -133,7 +133,7 @@ public class NativePortal extends FeatureObject {
                     blocks.add(new PortalBlock(loc));
                 } else if(o instanceof String) {
                     String data = (String) o;
-                    Location loc = de.codingair.codingapi.tools.Location.getByJSONString(data);
+                    Location loc = Location.getByJSONString(data);
 
                     if(loc == null || loc.getWorld() == null) {
                         destroy();
@@ -228,7 +228,7 @@ public class NativePortal extends FeatureObject {
         return isInPortal(entity, entity.getLocation());
     }
 
-    public boolean isInPortal(LivingEntity entity, Location target) {
+    public boolean isInPortal(LivingEntity entity, org.bukkit.Location target) {
         if(entity == null || target == null) return false;
 
         Location[] edges = getCachedEdges();
@@ -243,7 +243,7 @@ public class NativePortal extends FeatureObject {
         return false;
     }
 
-    public boolean isAround(Location location, double distance, boolean isExact) {
+    public boolean isAround(org.bukkit.Location location, double distance, boolean isExact) {
         if(Area.isInArea(location, getCachedEdges()[0], getCachedEdges()[1], true, distance)) {
             for(PortalBlock block : blocks) {
                 if(isExact && block.getLocation().distance(location) == distance) return true;

--- a/src/de/codingair/warpsystem/spigot/features/nativeportals/PortalEditor.java
+++ b/src/de/codingair/warpsystem/spigot/features/nativeportals/PortalEditor.java
@@ -113,7 +113,7 @@ public class PortalEditor implements Removable {
     }
 
     public void addPosition(Location location) {
-        this.nativePortal.addPortalBlock(new PortalBlock(location));
+        this.nativePortal.addPortalBlock(new PortalBlock(new de.codingair.codingapi.tools.Location(location)));
         update();
     }
 

--- a/src/de/codingair/warpsystem/spigot/features/nativeportals/utils/PortalBlock.java
+++ b/src/de/codingair/warpsystem/spigot/features/nativeportals/utils/PortalBlock.java
@@ -4,18 +4,18 @@ import de.codingair.codingapi.server.blocks.ModernBlock;
 import de.codingair.codingapi.server.blocks.data.Orientable;
 import de.codingair.codingapi.tools.Area;
 import de.codingair.warpsystem.spigot.features.nativeportals.NativePortal;
-import org.bukkit.Location;
+import de.codingair.codingapi.tools.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.LivingEntity;
 
 import java.lang.reflect.InvocationTargetException;
 
 public class PortalBlock {
-    private de.codingair.codingapi.tools.Location loc;
+    private Location loc;
 
     public PortalBlock(Location loc) {
-        loc = loc.getBlock().getLocation();
-        this.loc = new de.codingair.codingapi.tools.Location(loc);
+        this.loc = loc.clone();
+        this.loc.trim(0);
     }
 
     public de.codingair.codingapi.tools.Location getLocation() {
@@ -48,7 +48,7 @@ public class PortalBlock {
         return touches(e, e.getLocation());
     }
 
-    public boolean touches(LivingEntity e, Location target) {
+    public boolean touches(LivingEntity e, org.bukkit.Location target) {
         return Area.isInBlock(e, target, loc.getBlock());
     }
 }

--- a/src/de/codingair/warpsystem/spigot/features/playerwarps/commands/CPlayerWarp.java
+++ b/src/de/codingair/warpsystem/spigot/features/playerwarps/commands/CPlayerWarp.java
@@ -42,8 +42,7 @@ public class CPlayerWarp extends WarpSystemCommandBuilder {
                 l = new ArrayList<>(PlayerWarpManager.getManager().getForeignAvailableWarps((Player) sender));
                 for(PlayerWarp warp : l) {
                     String name = warp.getName(false).replace(" ", "_");
-                    suggestions.add((suggestions.contains(name) ? warp.getOwner().getName() + "." : "") + name);
-                    if(!suggestions.contains(warp.getOwner().getName())) suggestions.add(warp.getOwner().getName());
+                    suggestions.add(warp.getOwner().getName() + "." + name);
                 }
                 l.clear();
             }

--- a/src/de/codingair/warpsystem/spigot/features/playerwarps/utils/PlayerWarp.java
+++ b/src/de/codingair/warpsystem/spigot/features/playerwarps/utils/PlayerWarp.java
@@ -28,6 +28,7 @@ import de.codingair.warpsystem.transfer.packets.spigot.PlayerWarpTeleportProcess
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 
 import java.io.DataInputStream;
@@ -322,6 +323,13 @@ public class PlayerWarp extends FeatureObject {
         this.description = d.getList("description");
         this.teleportMessage = d.getString("tpmsg");
         this.item = d.getItemBuilder("item");
+
+        if(!XMaterial.isNewVersion() && this.item.getType() == XMaterial.PLAYER_HEAD.parseMaterial(false)) {
+            this.item.setType(XMaterial.PLAYER_HEAD.parseMaterial(true));
+            this.item.setDurability((byte) XMaterial.PLAYER_HEAD.getData());
+            this.item.setData((byte) XMaterial.PLAYER_HEAD.getData());
+        }
+
         this.isPublic = d.getBoolean("public");
         this.teleportCosts = d.getDouble("tpcosts");
         this.inactiveSales = d.getByte("sales");
@@ -415,7 +423,7 @@ public class PlayerWarp extends FeatureObject {
     }
 
     public boolean isStandardItem() {
-        return this.item != null && this.item.getType() == XMaterial.PLAYER_HEAD.parseMaterial() && Objects.equals(this.item.getSkullId(), WarpSystem.getInstance().getHeadManager().getSkinId(this.owner.id));
+        return this.item != null && this.item.getType() == XMaterial.PLAYER_HEAD.parseMaterial(true) && Objects.equals(this.item.getSkullId(), WarpSystem.getInstance().getHeadManager().getSkinId(this.owner.id));
     }
 
     public PlayerWarp clone() {

--- a/src/de/codingair/warpsystem/spigot/features/teleportcommand/listeners/TeleportPacketListener.java
+++ b/src/de/codingair/warpsystem/spigot/features/teleportcommand/listeners/TeleportPacketListener.java
@@ -130,7 +130,7 @@ public class TeleportPacketListener implements Listener, PacketListener {
                                     Lang.get("Teleported_To_By").replace("%gate%", gate.getName())
                             , false, null);
                 } else {
-                    TeleportListener.setSpawnPositionOrTeleport(tpPacket.getPlayer(), new de.codingair.codingapi.tools.Location(null, x, y, z, 0, 0), gate.getDisplayName(), gate == player ? Lang.get("Teleported_To") : Lang.get("Teleported_To_By").replace("%gate%", gate.getName()));
+                    TeleportListener.setSpawnPositionOrTeleport(tpPacket.getPlayer(), new de.codingair.codingapi.tools.Location((String) null, x, y, z, 0, 0), gate.getDisplayName(), gate == player ? Lang.get("Teleported_To") : Lang.get("Teleported_To_By").replace("%gate%", gate.getName()));
                 }
                 break;
             }


### PR DESCRIPTION
* NativePortals use de.codingair.codingapi.tools.Location now instead of org.bukkit.Location to save the world name