### PR TITLE
[WS-284] Telepots to offline servers are now cancelled correctly (err…

### DIFF
--- a/src/Config.yml
+++ b/src/Config.yml
@@ -39,7 +39,7 @@ WarpSystem:
     Animation_After_Teleport:
       Enabled: true
     Delay: 3
-    Allow_Move: true
+    Allow_Move: false
 
   Send:
     Teleport_Message:

--- a/src/de/codingair/warpsystem/spigot/base/managers/TeleportManager.java
+++ b/src/de/codingair/warpsystem/spigot/base/managers/TeleportManager.java
@@ -263,7 +263,7 @@ public class TeleportManager {
         Callback<?> waiting = new Callback() {
             @Override
             public void accept(Object object) {
-                Teleport teleport = new Teleport(player, options.getDestination(), options.getOrigin(), options.getDisplayName(), options.getPermission(), finalSeconds, options.getCosts(), finalMessage, options.isCanMove(), options.isSilent(), options.getTeleportSound(), options.isAfterEffects(), options.isTeleportAnimation(), new Callback<TeleportResult>() {
+                Teleport teleport = new Teleport(player, finalSeconds, options, new Callback<TeleportResult>() {
                     @Override
                     public void accept(TeleportResult object) {
                         options.runCallbacks(object);

--- a/src/de/codingair/warpsystem/spigot/base/utils/teleport/TeleportOptions.java
+++ b/src/de/codingair/warpsystem/spigot/base/utils/teleport/TeleportOptions.java
@@ -28,6 +28,7 @@ public class TeleportOptions {
     private String payMessage;
     private String paymentDeniedMessage;
     private String message;
+    private String serverNotOnline;
     private boolean silent;
     private SoundData teleportSound;
     private boolean afterEffects;
@@ -52,9 +53,10 @@ public class TeleportOptions {
         this.skip = false;
         this.canMove = WarpSystem.getInstance().getTeleportManager().getOptions().isAllowMove();
         this.waitForTeleport = false;
-        this.message = Lang.getPrefix() + (displayName == null ? Lang.get("Teleported_To") : Lang.get("Teleported_To").replace("%warp%", displayName));
         this.payMessage = Lang.getPrefix() + (displayName == null ? Lang.get("Money_Paid") : Lang.get("Money_Paid").replace("%warp%", displayName));
         this.paymentDeniedMessage = Lang.getPrefix() + Lang.get("Payment_denied");
+        this.message = Lang.getPrefix() + (displayName == null ? Lang.get("Teleported_To") : Lang.get("Teleported_To").replace("%warp%", displayName));
+        this.serverNotOnline = Lang.getPrefix() + Lang.get("Server_Is_Not_Online");
         this.silent = false;
         this.teleportSound = null;
         this.afterEffects = true;
@@ -218,5 +220,13 @@ public class TeleportOptions {
 
     public void setTeleportAnimation(boolean teleportAnimation) {
         this.teleportAnimation = teleportAnimation;
+    }
+
+    public String getServerNotOnline() {
+        return serverNotOnline;
+    }
+
+    public void setServerNotOnline(String serverNotOnline) {
+        this.serverNotOnline = serverNotOnline;
     }
 }

--- a/src/de/codingair/warpsystem/spigot/features/teleportcommand/listeners/BackListener.java
+++ b/src/de/codingair/warpsystem/spigot/features/teleportcommand/listeners/BackListener.java
@@ -3,6 +3,7 @@ package de.codingair.warpsystem.spigot.features.teleportcommand.listeners;
 import de.codingair.warpsystem.spigot.base.WarpSystem;
 import de.codingair.warpsystem.spigot.features.teleportcommand.TeleportCommandManager;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -21,9 +22,9 @@ public class BackListener implements Listener {
             TeleportCommandManager.getInstance().addToBackHistory(e.getEntity(), e.getEntity().getLocation());
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onTeleport(PlayerTeleportEvent e) {
-        if(!WarpSystem.hasPermission(e.getPlayer(), WarpSystem.PERMISSION_USE_TELEPORT_COMMAND_BACK)) return;
+        if(e.isCancelled() || !WarpSystem.hasPermission(e.getPlayer(), WarpSystem.PERMISSION_USE_TELEPORT_COMMAND_BACK)) return;
 
         if(e.getCause() != PlayerTeleportEvent.TeleportCause.PLUGIN && e.getCause() != PlayerTeleportEvent.TeleportCause.COMMAND) return;
         if(TeleportCommandManager.getInstance().getBackHistorySize() > 1 && TeleportCommandManager.getInstance().usingBackCommand(e.getPlayer())) return;


### PR DESCRIPTION
…or: SERVER_IS_NOT_ONLINE)

* Improved Teleport.class
* Cancelled teleports won't be recognized for /back anymore
* Allow_Move is set to false by default now