### PR TITLE
Update WarpSystem for Minecraft 1.21.11 compatibility

### DIFF
--- a/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-BungeeCord/pom.xml
+++ b/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-BungeeCord/pom.xml
@@ -56,15 +56,8 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
+            <version>1.20-R0.2</version>
             <type>jar</type>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.md-5</groupId>
-            <artifactId>bungeecord-api</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
-            <type>javadoc</type>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/api/events/FakeBlockBreakEvent.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/api/events/FakeBlockBreakEvent.java
@@ -29,10 +29,10 @@ public class FakeBlockBreakEvent extends BlockBreakEvent {
     private static final IReflection.FieldAccessor<PermissibleBase> PERMISSION_BASE = IReflection.getField(PacketUtils.CraftPlayerClass, PermissibleBase.class, 0);
     private static final IReflection.FieldAccessor<?> PLAYER_CONNECTION_FIELD = IReflection.getField(PacketUtils.EntityPlayerClass, PacketUtils.PlayerConnectionClass, 0);
 
-    private static final Class<?> PlayerInteractManagerClass = IReflection.getClass(IReflection.ServerPacket.MINECRAFT_PACKAGE("net.minecraft.server.level"), "PlayerInteractManager");
+    private static final Class<?> PlayerInteractManagerClass = IReflection.getClass(IReflection.ServerPacket.MINECRAFT_PACKAGE("net.minecraft.server.level"), Version.choose("PlayerInteractManager", 21.11, "ServerPlayerGameMode"));
 
     static {
-        Class<?> protocolDirection = IReflection.getClass(IReflection.ServerPacket.PROTOCOL, "EnumProtocolDirection");
+        Class<?> protocolDirection = IReflection.getClass(IReflection.ServerPacket.PROTOCOL, Version.choose("EnumProtocolDirection", 21.11, "PacketFlow"));
 
         if (Version.atLeast(20.02)) {
             Class<?> clientInformationClass = IReflection.getClass("net.minecraft.server.level.", "ClientInformation");

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/setupassistant/utils/SetupAssistantListener.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/setupassistant/utils/SetupAssistantListener.java
@@ -36,10 +36,10 @@ public class SetupAssistantListener implements PacketHandler<SetupAssistantStore
 
     private Object buildComponent(String message) {
         if (chatPacket == null) {
-            Class<?> packet = IReflection.getClass(IReflection.ServerPacket.MINECRAFT_PACKAGE, "PacketPlayOutChat");
+            Class<?> packet = IReflection.getClass(IReflection.ServerPacket.MINECRAFT_PACKAGE, Version.choose("PacketPlayOutChat", 21.11, "ClientboundChatPacket"));
 
             if (Version.after(15)) {
-                Class<?> type = IReflection.getClass(IReflection.ServerPacket.MINECRAFT_PACKAGE, "ChatMessageType");
+                Class<?> type = IReflection.getClass(IReflection.ServerPacket.MINECRAFT_PACKAGE, Version.choose("ChatMessageType", 21.11, "ChatType"));
                 this.type = type.getEnumConstants()[0];
                 chatPacket = IReflection.getConstructor(packet, PacketUtils.IChatBaseComponentClass, type, UUID.class);
             } else {

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/setupassistant/utils/versions/Messager_v1_17.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/setupassistant/utils/versions/Messager_v1_17.java
@@ -23,10 +23,10 @@ public class Messager_v1_17 implements Messager {
     public Messager_v1_17(@NotNull Player player, @NotNull SetupAssistant assistant) {
         this.player = player;
 
-        Class<?> iPacketClass = IReflection.getClass(IReflection.ServerPacket.PACKETS, "PacketPlayInChat");
+        Class<?> iPacketClass = IReflection.getClass(IReflection.ServerPacket.PACKETS, Version.choose("PacketPlayInChat", 21.11, "ServerboundChatPacket"));
         IReflection.FieldAccessor<String> inputText = IReflection.getField(iPacketClass, Version.choose("a", 17, "b"));
 
-        Class<?> oPacketClass = IReflection.getClass(IReflection.ServerPacket.PACKETS, "PacketPlayOutChat");
+        Class<?> oPacketClass = IReflection.getClass(IReflection.ServerPacket.PACKETS, Version.choose("PacketPlayOutChat", 21.11, "ClientboundChatPacket"));
         IReflection.FieldAccessor<?> outputText = IReflection.getField(oPacketClass, Version.choose("components", 17, "a"));
 
         IReflection.MethodAccessor getText = IReflection.getMethod(PacketUtils.IChatBaseComponentClass, Version.choose("getText", 18, "a"), String.class, new Class[0]);

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/setupassistant/utils/versions/Messager_v1_19.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/setupassistant/utils/versions/Messager_v1_19.java
@@ -30,7 +30,7 @@ public class Messager_v1_19 implements Messager {
     public Messager_v1_19(@NotNull Player player, @NotNull SetupAssistant assistant) {
         this.player = player;
 
-        Class<?> iPacketClass = IReflection.getClass(IReflection.ServerPacket.PACKETS, "PacketPlayInChat");
+        Class<?> iPacketClass = IReflection.getClass(IReflection.ServerPacket.PACKETS, Version.choose("PacketPlayInChat", 21.11, "ServerboundChatPacket"));
         IReflection.FieldAccessor<String> inputText = IReflection.getField(iPacketClass, String.class, 0);
 
         Class<?> oPlayerPacketClass = IReflection.getClass(IReflection.ServerPacket.PACKETS, "ClientboundPlayerChatPacket");

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/setupassistant/utils/versions/Messager_v1_8.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/setupassistant/utils/versions/Messager_v1_8.java
@@ -24,10 +24,10 @@ public class Messager_v1_8 implements Messager {
     public Messager_v1_8(@NotNull Player player, @NotNull SetupAssistant assistant) {
         this.player = player;
 
-        Class<?> iPacketClass = IReflection.getClass(IReflection.ServerPacket.PACKETS, "PacketPlayInChat");
+        Class<?> iPacketClass = IReflection.getClass(IReflection.ServerPacket.PACKETS, Version.choose("PacketPlayInChat", 21.11, "ServerboundChatPacket"));
         IReflection.FieldAccessor<String> inputText = IReflection.getField(iPacketClass, Version.choose("a", 17, "b"));
 
-        Class<?> oPacketClass = IReflection.getClass(IReflection.ServerPacket.PACKETS, "PacketPlayOutChat");
+        Class<?> oPacketClass = IReflection.getClass(IReflection.ServerPacket.PACKETS, Version.choose("PacketPlayOutChat", 21.11, "ClientboundChatPacket"));
         IReflection.FieldAccessor<?> outputText = IReflection.getField(oPacketClass, Version.choose("components", 17, "a"));
 
         reader = new PacketReader(player, "WS-SetupAssistant", WarpSystem.getInstance()) {

--- a/WarpSystem/pom.xml
+++ b/WarpSystem/pom.xml
@@ -54,6 +54,11 @@
             <id>md_5-snapshots</id>
             <url>https://repo.md-5.net/content/repositories/snapshots/</url>
         </repository>
+        <!--    BungeeCord snapshots    -->
+        <repository>
+            <id>sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
         <!-- Geyser/Floodgate API -->
         <repository>
             <id>opencollab-snapshot</id>


### PR DESCRIPTION
- Update pom.xml dependencies and add Sonatype snapshots repo
- Fix FakeBlockBreakEvent for 1.21.11
- Update SetupAssistant messagers for version compatibility