### PR TITLE
feat(tp): add '-silent' flag for /tp command with premission support

### DIFF
--- a/WarpSystem/WarpSystem-Bundle-Free/pom.xml
+++ b/WarpSystem/WarpSystem-Bundle-Free/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-8</version>
+        <version>5.1.16-silent-tp-command</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Bundle-Premium/pom.xml
+++ b/WarpSystem/WarpSystem-Bundle-Premium/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-8</version>
+        <version>5.1.16-silent-tp-command</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Core/pom.xml
+++ b/WarpSystem/WarpSystem-Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-8</version>
+        <version>5.1.16-silent-tp-command</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-BungeeCord/pom.xml
+++ b/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-BungeeCord/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem-Proxy</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-8</version>
+        <version>5.1.16-silent-tp-command</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-Core/pom.xml
+++ b/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem-Proxy</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-8</version>
+        <version>5.1.16-silent-tp-command</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-Velocity/pom.xml
+++ b/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-Velocity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem-Proxy</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-8</version>
+        <version>5.1.16-silent-tp-command</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Proxy/pom.xml
+++ b/WarpSystem/WarpSystem-Proxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-8</version>
+        <version>5.1.16-silent-tp-command</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Spigot-Free/pom.xml
+++ b/WarpSystem/WarpSystem-Spigot-Free/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-8</version>
+        <version>5.1.16-silent-tp-command</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Spigot-Free/src/main/java/de/codingair/warpsystem/spigot/versionfactory/handlers/TeleportCommandHandler.java
+++ b/WarpSystem/WarpSystem-Spigot-Free/src/main/java/de/codingair/warpsystem/spigot/versionfactory/handlers/TeleportCommandHandler.java
@@ -88,6 +88,11 @@ public class TeleportCommandHandler implements ITeleportCommandHandler {
 
     @Override
     public boolean tp(Player gate, PlayerData player, @Nullable Double x, @Nullable Double y, @Nullable Double z, @Nullable Float yaw, @Nullable Float pitch, @Nullable String server, @Nullable String world) {
+        return tp(gate, player, x, y, z, yaw, pitch, server, world, true);
+    }
+
+    @Override
+    public boolean tp(Player gate, PlayerData player, @Nullable Double x, @Nullable Double y, @Nullable Double z, @Nullable Float yaw, @Nullable Float pitch, @Nullable String server, @Nullable String world, boolean notifyPlayer) {
         if (checkStatusTp(gate, player)) return true;
         Player p = Bukkit.getPlayer(player.getName());
         if(p == null) return false;
@@ -147,6 +152,7 @@ public class TeleportCommandHandler implements ITeleportCommandHandler {
         TeleportOptions options = new TeleportOptions(new Destination(new LocationAdapter(l)), destination.toString(), Origin.TeleportCommand);
         options.setSkip(true);
         options.setMessage(Lang.getPrefix() + (gate == p ? Lang.get("Teleported_To") : Lang.get("Teleported_To_By").replace("%gate%", gate.getName())));
+        options.setNotifyPlayer(notifyPlayer);
 
         WarpSystem.getInstance().getTeleportManager().teleport(p, options);
         return true;
@@ -154,6 +160,11 @@ public class TeleportCommandHandler implements ITeleportCommandHandler {
 
     @Override
     public void tp(Player gate, PlayerData player, PlayerData target) {
+        tp(gate, player, target, true);
+    }
+
+    @Override
+    public void tp(Player gate, PlayerData player, PlayerData target, boolean notifyPlayer) {
         if (checkStatusTp(gate, player)) return;
         if (checkStatusTp(gate, target)) return;
 
@@ -175,6 +186,7 @@ public class TeleportCommandHandler implements ITeleportCommandHandler {
         TeleportOptions options = new TeleportOptions(new Destination(new LocationAdapter(targetP.getLocation())), targetP.getName(), Origin.TeleportCommand);
         options.setSkip(true);
         options.setMessage(Lang.getPrefix() + (gate == playerP ? Lang.get("Teleported_To") : Lang.get("Teleported_To_By").replace("%gate%", gate.getName())));
+        options.setNotifyPlayer(notifyPlayer);
 
         WarpSystem.getInstance().getTeleportManager().teleport(playerP, options);
     }

--- a/WarpSystem/WarpSystem-Spigot-Premium/pom.xml
+++ b/WarpSystem/WarpSystem-Spigot-Premium/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-8</version>
+        <version>5.1.16-silent-tp-command</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Spigot-Premium/src/main/java/de/codingair/warpsystem/spigot/versionfactory/handlers/TeleportCommandHandler.java
+++ b/WarpSystem/WarpSystem-Spigot-Premium/src/main/java/de/codingair/warpsystem/spigot/versionfactory/handlers/TeleportCommandHandler.java
@@ -134,6 +134,11 @@ public class TeleportCommandHandler implements ITeleportCommandHandler {
 
     @Override
     public boolean tp(Player gate, PlayerData player, @Nullable Double x, @Nullable Double y, @Nullable Double z, @Nullable Float yaw, @Nullable Float pitch, @Nullable String server, @Nullable String world) {
+        return tp(gate, player, x, y, z, yaw, pitch, server, world, true);
+    }
+
+    @Override
+    public boolean tp(Player gate, PlayerData player, @Nullable Double x, @Nullable Double y, @Nullable Double z, @Nullable Float yaw, @Nullable Float pitch, @Nullable String server, @Nullable String world, boolean notifyPlayer) {
         if (checkStatusTp(gate, player)) return true;
         Player p = Bukkit.getPlayer(player.getName());
 
@@ -207,6 +212,7 @@ public class TeleportCommandHandler implements ITeleportCommandHandler {
         TeleportOptions options = new TeleportOptions(new Destination(new LocationAdapter(l)), destination.toString(), Origin.TeleportCommand);
         options.setSkip(true);
         options.setMessage(Lang.getPrefix() + (gate == p ? Lang.get("Teleported_To") : Lang.get("Teleported_To_By").replace("%gate%", gate.getName())));
+        options.setNotifyPlayer(notifyPlayer);
 
         WarpSystem.getInstance().getTeleportManager().teleport(p, options);
         return true;
@@ -214,6 +220,11 @@ public class TeleportCommandHandler implements ITeleportCommandHandler {
 
     @Override
     public void tp(Player gate, PlayerData player, PlayerData target) {
+        tp(gate, player, target, true);
+    }
+
+    @Override
+    public void tp(Player gate, PlayerData player, PlayerData target, boolean notifyPlayer) {
         if (checkStatusTp(gate, player)) return;
         if (checkStatusTp(gate, target)) return;
 
@@ -238,6 +249,7 @@ public class TeleportCommandHandler implements ITeleportCommandHandler {
         TeleportOptions options = new TeleportOptions(new Destination(new LocationAdapter(targetP.getLocation())), targetP.getName(), Origin.TeleportCommand);
         options.setSkip(true);
         options.setMessage(Lang.getPrefix() + (gate == playerP ? Lang.get("Teleported_To") : Lang.get("Teleported_To_By").replace("%gate%", gate.getName())));
+        options.setNotifyPlayer(notifyPlayer);
 
         WarpSystem.getInstance().getTeleportManager().teleport(playerP, options);
     }

--- a/WarpSystem/WarpSystem-Spigot/pom.xml
+++ b/WarpSystem/WarpSystem-Spigot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-8</version>
+        <version>5.1.16-silent-tp-command</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/utils/Permissions.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/utils/Permissions.java
@@ -22,6 +22,7 @@ public class Permissions {
 
     private static final String PERMISSION_USE_TELEPORT_COMMAND = "warpsystem.use.teleportCommand";
     public static final String PERMISSION_USE_TELEPORT_COMMAND_TP = PERMISSION_USE_TELEPORT_COMMAND + ".tp";
+    public static final String PERMISSION_USE_TELEPORT_COMMAND_TP_SILENT = PERMISSION_USE_TELEPORT_COMMAND_TP + ".silent";
     public static final String PERMISSION_USE_TELEPORT_COMMAND_TPHERE = PERMISSION_USE_TELEPORT_COMMAND + ".tphere";
     public static final String PERMISSION_USE_TELEPORT_COMMAND_TPTO = PERMISSION_USE_TELEPORT_COMMAND + ".tpto";
     public static final String PERMISSION_USE_TELEPORT_COMMAND_TP_TOGGLE = PERMISSION_USE_TELEPORT_COMMAND + ".tptoggle";

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/utils/teleport/TeleportOptions.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/utils/teleport/TeleportOptions.java
@@ -40,6 +40,7 @@ public class TeleportOptions implements Options {
     private boolean waitForTeleport; //Waiting for walking teleports
     private boolean confirmPayment = true;
     private boolean silent;
+    private boolean notifyPlayer = true;
 
     private String payMessage;
     private String paymentDeniedMessage;
@@ -223,6 +224,14 @@ public class TeleportOptions implements Options {
 
     public void setSilent(boolean silent) {
         this.silent = silent;
+    }
+
+    public boolean isNotifyPlayer() {
+        return notifyPlayer;
+    }
+
+    public void setNotifyPlayer(boolean notifyPlayer) {
+        this.notifyPlayer = notifyPlayer;
     }
 
     public SoundData getTeleportSound() {

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/utils/teleport/process/PlayerTeleport.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/utils/teleport/process/PlayerTeleport.java
@@ -48,61 +48,68 @@ public class PlayerTeleport extends TeleportStage {
         String finalMessage = message;
 
         if (options.getOriginalDestination().usesBukkitTeleportation()) {
-            Bukkit.getPluginManager().registerEvents(listener = new Listener() {
-                @EventHandler (priority = EventPriority.MONITOR)
-                public void onTeleport(PlayerTeleportEvent e) {
-                    if (player.equals(e.getPlayer())) {
-                        afterEffectPosition.setValue(e.getTo());
+            org.bukkit.plugin.Plugin plugin = WarpSystem.getInstance();
+            if (plugin != null) {
+                Bukkit.getPluginManager().registerEvents(listener = new Listener() {
+                    @EventHandler (priority = EventPriority.MONITOR)
+                    public void onTeleport(PlayerTeleportEvent e) {
+                        if (player.equals(e.getPlayer())) {
+                            afterEffectPosition.setValue(e.getTo());
 
-                        if (e.isCancelled()) {
-                            String[] text = new String[2];
-                            String msg = Lang.get("Teleporting_Info");
+                            if (e.isCancelled()) {
+                                String[] text = new String[2];
+                                String msg = Lang.get("Teleporting_Info");
 
-                            if (d == TeleportDelay.Display.TITLE) {
-                                int i = msg.indexOf("\n");
-                                if (i != -1) {
-                                    text[0] = msg.substring(0, i);
-                                    text[1] = msg.substring(i + 2);
-                                } else text[0] = msg;
-                            }
-
-                            if (d == TeleportDelay.Display.ACTION_BAR) MessageAPI.sendActionBar(player, Lang.get("Teleport_Cancelled"));
-                            else if (d == TeleportDelay.Display.TITLE) MessageAPI.sendTitle(player, text[0], text[1], 2, 10, 2);
-                            HandlerList.unregisterAll(this);
-
-                            cancel(Result.CANCELLED);
-                        } else if (Version.atMost(8))
-                            Bukkit.getPluginManager().callEvent(new PlayerTeleportAcceptEvent(e.getPlayer())); //1.8 doesn't provide a packet based PlayerTeleportAcceptEvent
-                        else {
-                            new BukkitRunnable() {
-                                @Override
-                                public void run() {
-                                    Bukkit.getPluginManager().callEvent(new PlayerTeleportAcceptEvent(player));
+                                if (d == TeleportDelay.Display.TITLE) {
+                                    int i = msg.indexOf("\n");
+                                    if (i != -1) {
+                                        text[0] = msg.substring(0, i);
+                                        text[1] = msg.substring(i + 2);
+                                    } else text[0] = msg;
                                 }
-                            }.runTaskLater(WarpSystem.getInstance(), 5); //safety timeout (PlayerTeleportAcceptEvent doesn't get triggered while spawning)
+
+                                if (d == TeleportDelay.Display.ACTION_BAR) MessageAPI.sendActionBar(player, Lang.get("Teleport_Cancelled"));
+                                else if (d == TeleportDelay.Display.TITLE) MessageAPI.sendTitle(player, text[0], text[1], 2, 10, 2);
+                                HandlerList.unregisterAll(this);
+
+                                cancel(Result.CANCELLED);
+                            } else if (Version.atMost(8))
+                                Bukkit.getPluginManager().callEvent(new PlayerTeleportAcceptEvent(e.getPlayer())); //1.8 doesn't provide a packet based PlayerTeleportAcceptEvent
+                            else {
+                                new BukkitRunnable() {
+                                    @Override
+                                    public void run() {
+                                        Bukkit.getPluginManager().callEvent(new PlayerTeleportAcceptEvent(player));
+                                    }
+                                }.runTaskLater(plugin, 5); //safety timeout (PlayerTeleportAcceptEvent doesn't get triggered while spawning)
+                            }
                         }
                     }
-                }
 
-                @EventHandler
-                public void onTeleported(PlayerTeleportAcceptEvent e) {
-                    if (player.equals(e.getPlayer())) {
-                        if (player.isOnline()) {
-                            options.getOriginalDestination().sendMessage(player, finalMessage, options.getDisplayName(), options.getCosts(player), options.getOriginalOrigin());
-                            if (options.getTeleportSound() != null) options.getTeleportSound().play(player);
-                            end();
+                    @EventHandler
+                    public void onTeleported(PlayerTeleportAcceptEvent e) {
+                        if (player.equals(e.getPlayer())) {
+                            if (player.isOnline()) {
+                                if (options.isNotifyPlayer()) {
+                                    options.getOriginalDestination().sendMessage(player, finalMessage, options.getDisplayName(), options.getCosts(player), options.getOriginalOrigin());
+                                } else {
+                                    Bukkit.getLogger().info("[WarpSystem] Silent TP: " + player.getName() + " -> " + (options.getDisplayName() != null ? options.getDisplayName() : "destination"));
+                                }
+                                if (options.getTeleportSound() != null) options.getTeleportSound().play(player);
+                                end();
+                            }
                         }
                     }
-                }
 
-                @EventHandler
-                public void onQuit(PlayerQuitEvent e) {
-                    if (player.equals(e.getPlayer())) {
-                        HandlerList.unregisterAll(this);
-                        cancel(Result.DISCONNECT);
+                    @EventHandler
+                    public void onQuit(PlayerQuitEvent e) {
+                        if (player.equals(e.getPlayer())) {
+                            HandlerList.unregisterAll(this);
+                            cancel(Result.DISCONNECT);
+                        }
                     }
-                }
-            }, WarpSystem.getInstance());
+                }, plugin);
+            }
         }
 
         options.getOriginalDestination().teleport(player, message, options.getDisplayName(), options.getPermission() == null, options.isSilent(), options.getCosts(player), new Callback<Result>() {

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/features/teleportcommand/commands/CTeleport.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/features/teleportcommand/commands/CTeleport.java
@@ -18,6 +18,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class CTeleport extends WSCommandBuilder {
@@ -43,7 +45,19 @@ public class CTeleport extends WSCommandBuilder {
                 Player p = (Player) sender;
 
                 if (Permissions.hasPermission(p, Permissions.PERMISSION_USE_TELEPORT_COMMAND_TP)) {
-                    if (!process(p, args)) {
+                    List<String> argList = new ArrayList<>(Arrays.asList(args));
+                    boolean silentMode = false;
+                    if (argList.contains("-silent")) {
+                        if (Permissions.hasPermission(p, Permissions.PERMISSION_USE_TELEPORT_COMMAND_TP_SILENT)) {
+                            silentMode = true;
+                            argList.remove("-silent");
+                        } else {
+                            p.sendMessage(Lang.getPrefix() + Lang.get("No_Permission"));
+                            return true;
+                        }
+                    }
+                    args = argList.toArray(new String[0]);
+                    if (!process(p, args, silentMode)) {
                         String bracket = WarpSystem.opt().cmdSug();
                         String arg = WarpSystem.opt().cmdArg();
 
@@ -145,7 +159,7 @@ public class CTeleport extends WSCommandBuilder {
         return true;
     }
 
-    private static boolean process(Player p, String[] args) {
+    private static boolean process(Player p, String[] args, boolean silentMode) {
         if (args.length == 0) return false;
 
         String name = args[0];
@@ -156,7 +170,7 @@ public class CTeleport extends WSCommandBuilder {
         }
 
         if (args.length == 1 && data != null) {
-            TeleportCommandManager.handler().tp(p, WarpSystem.getInstance().getPlayerDataManager().getCache(p), data);
+            TeleportCommandManager.handler().tp(p, WarpSystem.getInstance().getPlayerDataManager().getCache(p), data, !silentMode);
             return true;
         }
 
@@ -168,16 +182,16 @@ public class CTeleport extends WSCommandBuilder {
 
                 if (otherData != null) {
                     //player name
-                    TeleportCommandManager.handler().tp(p, data, otherData);
+                    TeleportCommandManager.handler().tp(p, data, otherData, !silentMode);
                     return true;
                 }
             }
         }
 
-        return process(p, data, args);
+        return process(p, data, args, silentMode);
     }
 
-    private static boolean process(Player p, PlayerData other, String[] args) {
+    private static boolean process(Player p, PlayerData other, String[] args, boolean silentMode) {
         int i = 0;
         if (other != null) i++;
 
@@ -210,10 +224,10 @@ public class CTeleport extends WSCommandBuilder {
             }
         }
 
-        return process(p, other, x, y, z, args);
+        return process(p, other, x, y, z, args, silentMode);
     }
 
-    private static boolean process(Player p, PlayerData other, Double x, Double y, Double z, String[] args) {
+    private static boolean process(Player p, PlayerData other, Double x, Double y, Double z, String[] args, boolean silentMode) {
         int i = 0;
         if (other != null) i++;
         if (x != null) i += 3;
@@ -240,10 +254,10 @@ public class CTeleport extends WSCommandBuilder {
             }
         }
 
-        return process(p, other, x, y, z, yaw, pitch, args);
+        return process(p, other, x, y, z, yaw, pitch, args, silentMode);
     }
 
-    private static boolean process(Player p, PlayerData other, Double x, Double y, Double z, Float yaw, Float pitch, String[] args) {
+    private static boolean process(Player p, PlayerData other, Double x, Double y, Double z, Float yaw, Float pitch, String[] args, boolean silentMode) {
         int i = 0;
         if (other != null) i++;
         if (x != null) i += 3;
@@ -285,7 +299,7 @@ public class CTeleport extends WSCommandBuilder {
         }
 
         if (other == null) other = WarpSystem.getInstance().getPlayerDataManager().getCache(p);
-        return TeleportCommandManager.handler().tp(p, other, x, y, z, yaw, pitch, server, world);
+        return TeleportCommandManager.handler().tp(p, other, x, y, z, yaw, pitch, server, world, !silentMode);
     }
 
     private static boolean isNumeric(String s) {

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/features/teleportcommand/commands/ITeleportCommandHandler.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/features/teleportcommand/commands/ITeleportCommandHandler.java
@@ -16,7 +16,11 @@ public interface ITeleportCommandHandler {
 
     boolean tp(Player gate, PlayerData player, @Nullable Double x, @Nullable Double y, @Nullable Double z, @Nullable Float yaw, @Nullable Float pitch, @Nullable String server, @Nullable String world);
 
+    boolean tp(Player gate, PlayerData player, @Nullable Double x, @Nullable Double y, @Nullable Double z, @Nullable Float yaw, @Nullable Float pitch, @Nullable String server, @Nullable String world, boolean notifyPlayer);
+
     void tp(Player gate, PlayerData player, PlayerData target);
+
+    void tp(Player gate, PlayerData player, PlayerData target, boolean notifyPlayer);
 
     List<String> suggestTp(String[] args, List<String> suggestions);
 

--- a/WarpSystem/pom.xml
+++ b/WarpSystem/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.codingair</groupId>
     <artifactId>WarpSystem</artifactId>
-    <version>5.1.14_Hotfix-8</version>
+    <version>5.1.16-silent-tp-command</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
- Add `notifyPlayer` field to `TeleportOptions` for explicit state transfer.
- Implement safe argument parsing in `CTeleport` (removes `-silent` from any position).
- Add permission check for silent teleport usage.
- Overload `ITeleportCommandHandler` methods to propagate notification state.
- Update `PlayerTeleport` to log to console instead of chat when silent mode is active.

---

Tested on Paper 1.21.11 (`Paper version 1.21.11-88-main@8556cb4`).
Goal reached, works for me, will update this thread and/or Discord if I find any bugs/errors/etc.