### PR TITLE
Bump to 5.1.14_Hotfix-10 with CodingAPI 1.102

### DIFF
--- a/WarpSystem/WarpSystem-Bundle-Free/pom.xml
+++ b/WarpSystem/WarpSystem-Bundle-Free/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-9</version>
+        <version>5.1.14_Hotfix-10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Bundle-Premium/pom.xml
+++ b/WarpSystem/WarpSystem-Bundle-Premium/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-9</version>
+        <version>5.1.14_Hotfix-10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Core/pom.xml
+++ b/WarpSystem/WarpSystem-Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-9</version>
+        <version>5.1.14_Hotfix-10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-BungeeCord/pom.xml
+++ b/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-BungeeCord/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem-Proxy</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-9</version>
+        <version>5.1.14_Hotfix-10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-Core/pom.xml
+++ b/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem-Proxy</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-9</version>
+        <version>5.1.14_Hotfix-10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-Velocity/pom.xml
+++ b/WarpSystem/WarpSystem-Proxy/WarpSystem-Proxy-Velocity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem-Proxy</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-9</version>
+        <version>5.1.14_Hotfix-10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Proxy/pom.xml
+++ b/WarpSystem/WarpSystem-Proxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-9</version>
+        <version>5.1.14_Hotfix-10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Spigot-Free/pom.xml
+++ b/WarpSystem/WarpSystem-Spigot-Free/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-9</version>
+        <version>5.1.14_Hotfix-10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Spigot-Premium/pom.xml
+++ b/WarpSystem/WarpSystem-Spigot-Premium/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-9</version>
+        <version>5.1.14_Hotfix-10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/WarpSystem-Spigot/pom.xml
+++ b/WarpSystem/WarpSystem-Spigot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>WarpSystem</artifactId>
         <groupId>de.codingair</groupId>
-        <version>5.1.14_Hotfix-9</version>
+        <version>5.1.14_Hotfix-10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/WarpSystem/pom.xml
+++ b/WarpSystem/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.codingair</groupId>
     <artifactId>WarpSystem</artifactId>
-    <version>5.1.14_Hotfix-9</version>
+    <version>5.1.14_Hotfix-10</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -77,7 +77,7 @@
             <dependency>
                 <groupId>com.github.CodingAir</groupId>
                 <artifactId>CodingAPI</artifactId>
-                <version>1.101</version>
+                <version>1.102</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Picks up the AnvilGUI fix. Hotfix-9 / CodingAPI 1.101 threw ClassNotFoundException inside AnvilGUI.open() on Paper 1.21.11+/26.x