### PR TITLE
Fix repeated startup backup when Last_Version is unset

### DIFF
--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/WarpSystem.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/WarpSystem.java
@@ -187,6 +187,12 @@ public class WarpSystem extends JavaPlugin implements Proxy {
             oldVersion = config.getConfig().getString("Do_Not_Edit.Last_Version", "0");
             checkBackup(config, loadingFailed);
 
+            String currentVersion = getDescription().getVersion();
+            if (!currentVersion.equals(oldVersion)) {
+                config.getConfig().set("Do_Not_Edit.Last_Version", currentVersion);
+                config.saveConfig();
+            }
+
             Bukkit.getPluginManager().registerEvents(new PlayerDataListener(), this);
             Bukkit.getPluginManager().registerEvents(new TeleportListener(), this);
             Bukkit.getPluginManager().registerEvents(new NotifyListener(), this);

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/utils/Notifier.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/utils/Notifier.java
@@ -1,6 +1,5 @@
 package de.codingair.warpsystem.spigot.base.utils;
 
-import de.codingair.codingapi.files.ConfigFile;
 import de.codingair.warpsystem.spigot.base.WarpSystem;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
@@ -33,11 +32,6 @@ public class Notifier {
                 player.sendMessage("");
             }
 
-            ConfigFile file = WarpSystem.getInstance().getFileManager().getFile("Config");
-            if (!file.getConfig().getString("Do_Not_Edit.Last_Version", "").equals(WarpSystem.getInstance().getDescription().getVersion())) {
-                file.getConfig().set("Do_Not_Edit.Last_Version", WarpSystem.getInstance().getDescription().getVersion());
-                file.saveConfig();
-            }
         }
     }
 }


### PR DESCRIPTION
The Last_Version config write lived inside Notifier and only ran when an OP joined to see a notification. On servers with no OP login the value never got written, so the backup logic created a fresh backup on every restart. Moved to onEnable so it always runs.