### PR TITLE
Fix simpleWarps() API returning lowercase warp names

### DIFF
--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/managers/TeleportManager.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/managers/TeleportManager.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.Unmodifiable;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class TeleportManager implements ITeleportManager {
     public static final String NO_PERMISSION = "%NO_PERMISSION%";
@@ -174,7 +175,11 @@ public class TeleportManager implements ITeleportManager {
         SimpleWarpManager man = SimpleWarpManager.getInstance();
         if (man == null) return Collections.emptySet();
 
-        return Collections.unmodifiableSet(man.getWarps().keySet());
+        return Collections.unmodifiableSet(
+                man.getWarps().values().stream()
+                        .map(warp -> warp.getName(true))
+                        .collect(Collectors.toSet())
+        );
     }
 
     @Override


### PR DESCRIPTION
`simpleWarps()` returns the internal map's keySet, but the keys are stored lowercase for case-insensitive lookups. A warp called `HeLLo` comes back from the API as `hello`, which breaks plugins that try to display warp lists.

Switched to reading names from the `SimpleWarp` values instead. `simpleWarp(String id)` is unaffected, lookup stays case-insensitive.

`globalWarps()` doesn't have the same issue: GlobalWarpManager keeps original case and uses `equalsIgnoreCase` for lookups.

Closes erikzimmermann/WarpSystem-IssueTracker#787