### PR TITLE
Use Paper's AsyncPlayerSpawnLocationEvent when available

### DIFF
--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/WarpSystem.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/WarpSystem.java
@@ -40,6 +40,7 @@ import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.MemorySection;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -188,7 +189,9 @@ public class WarpSystem extends JavaPlugin implements Proxy {
             checkBackup(config, loadingFailed);
 
             Bukkit.getPluginManager().registerEvents(new PlayerDataListener(), this);
-            Bukkit.getPluginManager().registerEvents(new TeleportListener(), this);
+            TeleportListener teleportListener = new TeleportListener();
+            Bukkit.getPluginManager().registerEvents(teleportListener, this);
+            SpawnLocationEvents.register(teleportListener, this, EventPriority.HIGHEST, true, teleportListener::onSpawn);
             Bukkit.getPluginManager().registerEvents(new NotifyListener(), this);
             Bukkit.getPluginManager().registerEvents(new CommandListener(), this);
 

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/listeners/SpawnLocationEvents.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/listeners/SpawnLocationEvents.java
@@ -1,0 +1,41 @@
+package de.codingair.warpsystem.spigot.base.listeners;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.spigotmc.event.player.PlayerSpawnLocationEvent;
+
+import java.util.function.Consumer;
+
+/**
+ * Registers handlers for {@link PlayerSpawnLocationEvent}, preferring Paper's
+ * {@code AsyncPlayerSpawnLocationEvent} subclass when available. Paper warns on
+ * registrations against the parent event because the registration itself causes
+ * the player to be created early; subscribing to the async subclass avoids that.
+ * The handler body uses parent-class API only, so it works on plain Spigot too.
+ */
+public final class SpawnLocationEvents {
+    private static final Class<? extends PlayerSpawnLocationEvent> EVENT_CLASS = resolve();
+
+    private SpawnLocationEvents() {
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<? extends PlayerSpawnLocationEvent> resolve() {
+        try {
+            return (Class<? extends PlayerSpawnLocationEvent>) Class.forName(
+                    "com.destroystokyo.paper.event.player.AsyncPlayerSpawnLocationEvent");
+        } catch (ClassNotFoundException ignored) {
+            return PlayerSpawnLocationEvent.class;
+        }
+    }
+
+    public static void register(Listener listener, JavaPlugin plugin, EventPriority priority,
+                                boolean ignoreCancelled, Consumer<PlayerSpawnLocationEvent> handler) {
+        Bukkit.getPluginManager().registerEvent(
+                EVENT_CLASS, listener, priority,
+                (l, event) -> handler.accept((PlayerSpawnLocationEvent) event),
+                plugin, ignoreCancelled);
+    }
+}

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/listeners/TeleportListener.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/base/listeners/TeleportListener.java
@@ -75,7 +75,6 @@ public class TeleportListener implements Listener {
         }
     }
 
-    @EventHandler (priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onSpawn(PlayerSpawnLocationEvent e) {
         try {
             TeleportData data = teleport.getIfPresent(e.getPlayer().getName().toLowerCase());

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/features/randomteleports/listeners/SpawnListener.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/features/randomteleports/listeners/SpawnListener.java
@@ -17,7 +17,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -71,7 +70,6 @@ public class SpawnListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
     public void onSpawn(PlayerSpawnLocationEvent e) {
         // runs before PlayerJoinEvent
 

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/features/randomteleports/managers/RandomTeleportManager.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/features/randomteleports/managers/RandomTeleportManager.java
@@ -13,6 +13,7 @@ import de.codingair.warpsystem.core.transfer.packets.spigot.QueueRTPUsagePacket;
 import de.codingair.warpsystem.core.transfer.packets.spigot.RandomTPWorldsPacket;
 import de.codingair.warpsystem.core.utils.Manager;
 import de.codingair.warpsystem.spigot.base.WarpSystem;
+import de.codingair.warpsystem.spigot.base.listeners.SpawnLocationEvents;
 import de.codingair.warpsystem.spigot.base.setupassistant.annotations.AvailableForSetupAssistant;
 import de.codingair.warpsystem.spigot.base.setupassistant.annotations.Function;
 import de.codingair.warpsystem.spigot.base.utils.Lang;
@@ -39,6 +40,7 @@ import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.jetbrains.annotations.NotNull;
@@ -168,6 +170,7 @@ public abstract class RandomTeleportManager implements Manager, ProxyFeature {
 
         SpawnListener listener = new SpawnListener();
         Bukkit.getPluginManager().registerEvents(listener, WarpSystem.getInstance());
+        SpawnLocationEvents.register(listener, WarpSystem.getInstance(), EventPriority.HIGHEST, false, listener::onSpawn);
         WarpSystem.getDataHandler().registerHandler(QueueRTPUsagePacket.class, new QueueRTPUsagePacketHandler());
 
         boolean success = true;

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/features/spawn/listeners/SpawnListener.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/features/spawn/listeners/SpawnListener.java
@@ -13,7 +13,6 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 
 public class SpawnListener implements Listener {
-    @EventHandler (priority = EventPriority.HIGH)
     public void onSpawn(PlayerSpawnLocationEvent e) {
         Spawn spawn = SpawnManager.getInstance().getSpawn();
         if (spawn != null) {

--- a/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/features/spawn/managers/SpawnManager.java
+++ b/WarpSystem/WarpSystem-Spigot/src/main/java/de/codingair/warpsystem/spigot/features/spawn/managers/SpawnManager.java
@@ -5,6 +5,7 @@ import de.codingair.codingapi.tools.io.ConfigMask;
 import de.codingair.warpsystem.core.transfer.packets.general.SendGlobalSpawnOptionsPacket;
 import de.codingair.warpsystem.core.utils.Manager;
 import de.codingair.warpsystem.spigot.base.WarpSystem;
+import de.codingair.warpsystem.spigot.base.listeners.SpawnLocationEvents;
 import de.codingair.warpsystem.spigot.base.setupassistant.annotations.AvailableForSetupAssistant;
 import de.codingair.warpsystem.spigot.base.setupassistant.annotations.Function;
 import de.codingair.warpsystem.spigot.base.utils.featureobjects.actions.types.WarpAction;
@@ -20,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventPriority;
 
 import java.io.File;
 import java.util.Objects;
@@ -55,6 +57,7 @@ public class SpawnManager implements Manager {
 
         SpawnListener listener = new SpawnListener();
         Bukkit.getPluginManager().registerEvents(listener, WarpSystem.getInstance());
+        SpawnLocationEvents.register(listener, WarpSystem.getInstance(), EventPriority.HIGH, false, listener::onSpawn);
 
         new CSetSpawn().register();
         new CSpawn().register();


### PR DESCRIPTION
Paper 1.21.11/26.1.2 prints a deprecation warning for our listeners on `PlayerSpawnLocationEvent` and recommends `AsyncPlayerSpawnLocationEvent` instead.

The project builds against spigot-api so we can't import the Paper class directly. Added a `SpawnLocationEvents` helper that does `Class.forName` for the Paper subclass once at class load and registers whichever event is available. Handlers stay on the parent class so it still works on Spigot.

Three listeners were affected: `TeleportListener`, the randomteleports `SpawnListener`, and the spawn `SpawnListener`. All three now go through the helper.

Tested on Paper 1.21.11/26.1.2, all three warnings gone from the startup log.

Closes #1148